### PR TITLE
Feature/cmd tests

### DIFF
--- a/cmd/cmd_migrator_test.go
+++ b/cmd/cmd_migrator_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	pms "github.com/Moranilt/pms/migrator"
+	"github.com/jmoiron/sqlx"
+)
+
+type mockedMigrator struct {
+	up      bool
+	down    bool
+	version bool
+}
+
+func NewMockedMigrator() (CreateMigrator, *mockedMigrator) {
+	m := &mockedMigrator{}
+	return func(db *sqlx.DB, path string) (pms.Migrator, error) {
+		return m, nil
+	}, m
+}
+
+func (m *mockedMigrator) Up() error {
+	m.up = true
+	return nil
+}
+func (m *mockedMigrator) Down() error {
+	m.down = true
+	return nil
+}
+func (m *mockedMigrator) Version(version int) error {
+	m.version = true
+	return nil
+}
+
+func (m *mockedMigrator) Test(t *testing.T, args ...string) {
+	t.Helper()
+	for _, name := range args {
+		switch name {
+		case "up":
+			if !m.up {
+				t.Error("expected to call Up function")
+			}
+		case "down":
+			if !m.down {
+				t.Error("expected to call Down function")
+			}
+		case "version":
+			if !m.version {
+				t.Error("expected to call Version function")
+			}
+		}
+	}
+}
+
+type mockedPms struct {
+	mock sqlmock.Sqlmock
+	db   *sqlx.DB
+}
+
+func CreateMockedMigrator() (*mockedPms, error) {
+	mockedDB, mock, err := sqlmock.New()
+	if err != nil {
+		return nil, err
+	}
+	db := sqlx.NewDb(mockedDB, "sqlmock")
+	return &mockedPms{mock: mock, db: db}, nil
+}
+
+func (m *mockedPms) MakeDefaultMock() {
+	m.mock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf(pms.QUERY_CREATE_TABLE, pms.TABLE_NAME))).WillReturnResult(sqlmock.NewResult(1, 1))
+	rows := sqlmock.NewRows([]string{"version"}).AddRow(0)
+	m.mock.ExpectQuery(pms.SELECT_VERSION).WillReturnRows(rows)
+}
+
+func (m *mockedPms) MakeFakeConnection(conn string) (*sqlx.DB, error) {
+	return m.db, nil
+}
+
+func TestCmdMigrator(t *testing.T) {
+	os.Mkdir(DEFAULT_SOURCE, 0777)
+	defer os.RemoveAll(DEFAULT_SOURCE)
+	t.Run("db empty", func(t *testing.T) {
+		mockePMS, err := CreateMockedMigrator()
+		if err != nil {
+			t.Error(err)
+		}
+		m := &CmdMigrator{}
+		err = m.Run(mockePMS.MakeFakeConnection)
+
+		if err.Error() != ERROR_DB_REQUIRED {
+			t.Errorf("got %q, expected %q", err.Error(), ERROR_DB_REQUIRED)
+		}
+	})
+
+	t.Run("only db is set", func(t *testing.T) {
+		m := &CmdMigrator{
+			db:      "test_db",
+			source:  DEFAULT_SOURCE,
+			version: DEFAULT_VERSION,
+		}
+
+		mockePMS, err := CreateMockedMigrator()
+		if err != nil {
+			t.Error(err)
+		}
+		mockePMS.MakeDefaultMock()
+
+		err = m.Run(mockePMS.MakeFakeConnection)
+
+		if err.Error() != ERROR_NOT_PROVIDED_ACTION {
+			t.Errorf("got %q, expected %q", err.Error(), ERROR_NOT_PROVIDED_ACTION)
+		}
+	})
+
+	t.Run("only db and 'up' flag", func(t *testing.T) {
+		createMigrator, migrator := NewMockedMigrator()
+		m := New(createMigrator)
+		m.up = true
+		m.db = "test_db"
+
+		mockePMS, err := CreateMockedMigrator()
+		if err != nil {
+			t.Error(err)
+		}
+		mockePMS.MakeDefaultMock()
+
+		err = m.Run(mockePMS.MakeFakeConnection)
+		if err != nil {
+			t.Error(err)
+		}
+		migrator.Test(t, "up")
+	})
+	t.Run("only db and 'down' flag", func(t *testing.T) {
+		createMigrator, migrator := NewMockedMigrator()
+		m := New(createMigrator)
+		m.down = true
+		m.db = "test_db"
+
+		mockePMS, err := CreateMockedMigrator()
+		if err != nil {
+			t.Error(err)
+		}
+		mockePMS.MakeDefaultMock()
+
+		err = m.Run(mockePMS.MakeFakeConnection)
+		if err != nil {
+			t.Error(err)
+		}
+		migrator.Test(t, "down")
+	})
+	t.Run("only db and 'version' flag", func(t *testing.T) {
+		createMigrator, migrator := NewMockedMigrator()
+		m := New(createMigrator)
+		m.version = 1
+		m.db = "test_db"
+
+		mockePMS, err := CreateMockedMigrator()
+		if err != nil {
+			t.Error(err)
+		}
+		mockePMS.MakeDefaultMock()
+
+		err = m.Run(mockePMS.MakeFakeConnection)
+		if err != nil {
+			t.Error(err)
+		}
+		migrator.Test(t, "version")
+	})
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,84 +10,155 @@ import (
 	_ "github.com/lib/pq"
 )
 
+const (
+	DEFAULT_SOURCE  = "migrations"
+	DEFAULT_VERSION = -1
+	DEFAULT_PORT    = 5432
+	DEFAULT_HOST    = "localhost"
+	DEFAULT_DB      = ""
+	DEFAULT_USER    = "root"
+	DEFAULT_PASS    = ""
+
+	ERROR_DB_REQUIRED         = "error: 'db' flag required"
+	ERROR_NOT_PROVIDED_ACTION = "error: provide 'up', 'down' or 'version' flag"
+)
+
+type CreateMigrator = func(db *sqlx.DB, path string) (pms.Migrator, error)
 type CmdMigrator struct {
-	source  string
-	up      bool
-	down    bool
-	host    string
-	port    int
-	db      string
-	user    string
-	pass    string
-	version int
+	source         string
+	up             bool
+	down           bool
+	host           string
+	port           int
+	db             string
+	user           string
+	pass           string
+	version        int
+	createMigrator CreateMigrator
+}
+
+func New(c CreateMigrator) *CmdMigrator {
+	return &CmdMigrator{
+		createMigrator: c,
+		source:         DEFAULT_SOURCE,
+		host:           DEFAULT_HOST,
+		pass:           DEFAULT_PASS,
+		port:           DEFAULT_PORT,
+		db:             DEFAULT_DB,
+		user:           DEFAULT_USER,
+		version:        DEFAULT_VERSION,
+	}
+}
+
+type FlagType[T int | string | bool] struct {
+	Pointer      *T
+	Name         string
+	DefaultValue T
+	Usage        string
+}
+
+func (c *CmdMigrator) StringFlags() []FlagType[string] {
+	return []FlagType[string]{
+		{&c.source, "source", DEFAULT_SOURCE, "Source of migration files. For example './migrations'"},
+		{&c.host, "host", DEFAULT_HOST, "Database host"},
+		{&c.db, "db", DEFAULT_DB, "Database name"},
+		{&c.user, "user", DEFAULT_USER, "Database user"},
+		{&c.pass, "pass", DEFAULT_PASS, "Database password"},
+	}
+}
+
+func (c *CmdMigrator) BoolFlags() []FlagType[bool] {
+	return []FlagType[bool]{
+		{&c.up, "up", false, "Run all migrations from provided path"},
+		{&c.down, "down", false, "Run all down migrations from provided path"},
+	}
+}
+
+func (c *CmdMigrator) IntFlags() []FlagType[int] {
+	return []FlagType[int]{
+		{&c.port, "port", DEFAULT_PORT, "Database port"},
+		{&c.version, "v", DEFAULT_VERSION, "Select version of migrations"},
+	}
 }
 
 func (c *CmdMigrator) GetFlags() {
-	flag.StringVar(&c.source, "source", "./migrations", "Source of migration files. For example './migrations'")
-	flag.BoolVar(&c.up, "up", false, "Run all migrations from provided path")
-	flag.BoolVar(&c.down, "down", false, "Run all down migrations from provided path")
-	flag.StringVar(&c.host, "host", "localhost", "Database host")
-	flag.IntVar(&c.port, "port", 5432, "Database port")
-	flag.StringVar(&c.db, "db", "", "Database name")
-	flag.StringVar(&c.user, "user", "root", "Database user")
-	flag.StringVar(&c.pass, "pass", "", "Database password")
-	flag.IntVar(&c.version, "v", -1, "Select version of migrations")
+	for _, f := range c.StringFlags() {
+		flag.StringVar(f.Pointer, f.Name, f.DefaultValue, f.Usage)
+	}
+
+	for _, f := range c.BoolFlags() {
+		flag.BoolVar(f.Pointer, f.Name, f.DefaultValue, f.Usage)
+	}
+
+	for _, f := range c.IntFlags() {
+		flag.IntVar(f.Pointer, f.Name, f.DefaultValue, f.Usage)
+	}
 	flag.Parse()
 }
 
-func (c *CmdMigrator) Run() {
-	c.db = strings.ToValidUTF8(strings.ReplaceAll(c.db, " ", ""), "")
-	if c.db == "" || len(c.db) == 0 {
-		fmt.Println("Error: 'db' flag required")
-		return
-	}
-
-	if !c.up && !c.down && c.version == -1 {
-		fmt.Println("Error: provide 'up', 'down' or 'version' flag")
-		return
-	}
-
-	conn := fmt.Sprintf(
+func (c *CmdMigrator) MakeConnectionString() string {
+	return fmt.Sprintf(
 		"host=%s dbname=%s user=%s password=%s port=%d sslmode=disable",
 		c.host, c.db, c.user, c.pass, c.port,
 	)
-	db, err := sqlx.Connect("postgres", conn)
+}
+
+func (c *CmdMigrator) Run(makeConnection func(string) (*sqlx.DB, error)) error {
+	c.db = strings.ToValidUTF8(strings.ReplaceAll(c.db, " ", ""), "")
+	if c.db == "" || len(c.db) == 0 {
+		return fmt.Errorf("error: 'db' flag required")
+	}
+
+	if !c.up && !c.down && c.version == -1 {
+		return fmt.Errorf(ERROR_NOT_PROVIDED_ACTION)
+	}
+
+	db, err := makeConnection(c.MakeConnectionString())
 	if err != nil {
-		fmt.Printf("Error while connecting to db: %v\n", err)
-		return
+		return err
 	}
 	defer db.Close()
 
-	m, err := pms.New(db, c.source)
+	m, err := c.createMigrator(db, c.source)
 	if err != nil {
-		fmt.Println(err)
-		return
+		return err
 	}
 	if c.up {
 		err := m.Up()
 		if err != nil {
-			fmt.Println(err)
+			return err
 		}
-		return
+		return nil
 	}
 	if c.down {
 		err := m.Down()
 		if err != nil {
-			fmt.Println(err)
+			return err
 		}
-		return
+		return nil
 	}
 	if c.version != -1 {
 		err := m.Version(c.version)
 		if err != nil {
-			fmt.Println(err)
+			return err
 		}
-		return
+		return nil
 	}
+	return nil
+}
+
+func makeConnection(conn string) (*sqlx.DB, error) {
+	db, err := sqlx.Connect("postgres", conn)
+	if err != nil {
+		return nil, fmt.Errorf("error while connecting to db: %w", err)
+	}
+
+	return db, nil
 }
 
 func main() {
-	cmd := &CmdMigrator{}
+	cmd := New(pms.New)
 	cmd.GetFlags()
-	cmd.Run()
+	err := cmd.Run(makeConnection)
+	fmt.Println(err)
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,1 +1,0 @@
-package main

--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -24,12 +24,17 @@ const (
 	DIRECTION_DOWN Direction = "down"
 )
 
-type Migrator struct {
+type Migrator interface {
+	Up() error
+	Down() error
+	Version(int) error
+}
+type Migration struct {
 	db   *sqlx.DB
 	path string
 }
 
-func New(db *sqlx.DB, path string) (*Migrator, error) {
+func New(db *sqlx.DB, path string) (Migrator, error) {
 	_, err := readDir(path)
 	if err != nil {
 		return nil, err
@@ -47,10 +52,10 @@ func New(db *sqlx.DB, path string) (*Migrator, error) {
 		}
 	}
 
-	return &Migrator{db: db, path: path}, nil
+	return &Migration{db: db, path: path}, nil
 }
 
-func (m *Migrator) Up() error {
+func (m *Migration) Up() error {
 	files, err := readDir(m.path)
 	if err != nil {
 		return err
@@ -82,7 +87,7 @@ func (m *Migrator) Up() error {
 	return nil
 }
 
-func (m *Migrator) Down() error {
+func (m *Migration) Down() error {
 	files, err := readDir(m.path)
 	if err != nil {
 		return err
@@ -113,7 +118,7 @@ func (m *Migrator) Down() error {
 	return nil
 }
 
-func (m *Migrator) Version(version int) error {
+func (m *Migration) Version(version int) error {
 	files, err := readDir(m.path)
 	if err != nil {
 		return err

--- a/migrator/utils.go
+++ b/migrator/utils.go
@@ -61,7 +61,7 @@ func getVersionFromName(name string) int {
 
 func readDir(path string) ([]fs.DirEntry, error) {
 	if files, err := os.ReadDir(path); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("directory %q not found. Error: %w", path, err)
 	} else {
 		return files, err
 	}


### PR DESCRIPTION
-  change error message for readDir
- rename instances:
    - rename Migrator  structure to Migration
    - replace return type to New function with `Migrator` interface
- refactor CMD:
    - add constants with defaults
    - add `New` function
    - add `StringFlags`, `BoolFlags` and `IntFlags` functions
    - add `MakeConnectionString` function
    - change return type of `Run` function
- add tests to CMD